### PR TITLE
fix(ts): use explicit types in ts definitions

### DIFF
--- a/Sources/Common/Core/ScalarsToColors/index.d.ts
+++ b/Sources/Common/Core/ScalarsToColors/index.d.ts
@@ -134,7 +134,7 @@ export interface vtkScalarsToColors extends vtkObject {
 	 * otherwise return isOpaque()
 	 * @see isOpaque, getAlpha
 	 */
-	areScalarsOpaque(scalars, colorMode, componentIn): boolean;
+	areScalarsOpaque(scalars: any, colorMode: number, componentIn: number): boolean;
 
 	/**
 	 * 


### PR DESCRIPTION
### Context
- to fix TypeScript compilation errors due to the implicit `any` type
```
Error: node_modules/vtk.js/Sources/Common/Core/ScalarsToColors/index.d.ts:137:39 - error TS7006: Parameter 'componentIn' implicitly has an 'any' type.

137  areScalarsOpaque(scalars, colorMode, componentIn): boolean;
```
- to be compliant with (https://github.com/Kitware/VTK/blob/master/Common/Core/vtkScalarsToColors.cxx#L9)

### Changes
- added explicit types for the parameters of the `areScalarsOpaque` function

### PR and Code Checklist
- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code
